### PR TITLE
Updated rollup to version 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "memdown": "1.1.0",
     "mocha": "2.3.3",
     "pouchdb": "4.0.3",
-    "rollup": "0.17.3",
+    "rollup": "0.18.1",
     "uglifyjs": "2.4.10"
   },
   "dependencies": {


### PR DESCRIPTION
:rocket:

rollup just published version 0.18.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 179 commits (ahead by 179, behind by 12).
- [5533c3f](https://github.com/rollup/rollup/commit/5533c3f277c42af6f60a5f8b244beb6d7d3cecb8): Merge pull request #165 from rollup/lean
- [3aef654](https://github.com/rollup/rollup/commit/3aef6541d53f82ef385b1b506974a78c1a5c3889): Merge commit '5353ee034dca9261545d35eb595eb28045446d82' of https://github.com/rollup/rollup
- [6939130](https://github.com/rollup/rollup/commit/693913016f76b8d455798bd53554cdafd4b1d485): argh windows
- [e8fe0d1](https://github.com/rollup/rollup/commit/e8fe0d10806c89e4526b367ee9f616517bb5a06b): make intermediate dirs in writeFile helper
- [7a1eeab](https://github.com/rollup/rollup/commit/7a1eeabc2c51b58aecd385da06e7694b09fff724): fix travis error, hopefully
- [90e7a8d](https://github.com/rollup/rollup/commit/90e7a8d435600ae26d526bc03d0706a146f565e1): -> 0.18.1
- [4eeb082](https://github.com/rollup/rollup/commit/4eeb082e7920746497200422501b0de333693c5d): include es6-promise
- [10e6387](https://github.com/rollup/rollup/commit/10e63875ddc7a316ce354a94413eb2a71957848c): remove unused deps
- [c46afb5](https://github.com/rollup/rollup/commit/c46afb57c178dab06a643056db3870043604cc75): roll up acorn
- [4ac7fe8](https://github.com/rollup/rollup/commit/4ac7fe8486162ba55267a0ca41801d2532c07c60): move deps to devDeps as applicable
- [dfa6492](https://github.com/rollup/rollup/commit/dfa6492bf8205b24cf970fba460d90ee1e30cf7c): remove sander dependency
- [73eefbe](https://github.com/rollup/rollup/commit/73eefbed871805b0e2f27b1870dd12fc181e06c3): Merge pull request #163 from rollup/rewrite-master
- [8e8895c](https://github.com/rollup/rollup/commit/8e8895c3ab3ec843875a5ac5063b862aef9f57b3): Merge branch 'deshadow-bug' into rewrite-master
- [567bd38](https://github.com/rollup/rollup/commit/567bd38ace45c211c714c2a8dff8b8351ce675ea): prevent deshadowing logic causing double rewrites
- [90ba35b](https://github.com/rollup/rollup/commit/90ba35b60adf9abb7df0a099da3ae7c3107ae5b4): --no-indent cli option

There are 179 commits in total. See the [full diff](https://github.com/rollup/rollup/compare/54ea4dbbcd5dc59e1e3f2903f7be9bec5dbf9f73...5533c3f277c42af6f60a5f8b244beb6d7d3cecb8).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
