### PR TITLE
Updated rollup to version 0.18.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "memdown": "1.1.0",
     "mocha": "2.3.3",
     "pouchdb": "4.0.3",
-    "rollup": "0.18.2",
+    "rollup": "0.18.4",
     "uglifyjs": "2.4.10"
   },
   "dependencies": {


### PR DESCRIPTION
:rocket:

rollup just published version 0.18.4, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 5 commits (ahead by 5, behind by 0).
- [ac67ff7](https://github.com/rollup/rollup/commit/ac67ff7d5ccdadb59dbee6a6901b41bdef95b38e): -> 0.18.4
- [fd3ae38](https://github.com/rollup/rollup/commit/fd3ae38c18f0d8a092d3604f3efd9e3caaff51bc): make external modules configurable
- [a4aae7e](https://github.com/rollup/rollup/commit/a4aae7e78a9120aa01c5feb1de35f16ce8e9a0a0): -> 0.18.3
- [f925103](https://github.com/rollup/rollup/commit/f9251038630a6e42c0c251271251dee5499c94bd): only exclude strings with newlines, and crop out enclosing quotes - fixes #166
- [65e7cb9](https://github.com/rollup/rollup/commit/65e7cb9eed8f13f8d2c9d2ac8378047f32b916ba): include second test for #154

See the [full diff](https://github.com/rollup/rollup/compare/22028303621d45afb1a424f91cb0442c5d6be6a0...ac67ff7d5ccdadb59dbee6a6901b41bdef95b38e).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
